### PR TITLE
Fix relationship with undef value

### DIFF
--- a/manifests/community_modules.pp
+++ b/manifests/community_modules.pp
@@ -12,7 +12,7 @@ class prosody::community_modules (
     default: { $_packages = [] }
   }
   ensure_packages($_packages)
-  -> vcsrepo { $path:
+  Package[$_packages] -> vcsrepo { $path:
     ensure   => $ensure,
     provider => $type,
     source   => $source,


### PR DESCRIPTION
#### Pull Request (PR) description
With Puppet 6.20 using the `community_modules` class produces this error:
```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Illegal relationship operand, can not form a relationship with an Undef Value. A Catalog type is required. (file: /etc/puppetlabs/code/environments/master/modules/prosody/manifests/community_modules.pp, line: 15, column: 3) on node [...]
```
This PR fixes this by defining the list of packages for the given type as the left operand for the relationship.

#### This Pull Request (PR) fixes the following issues
n/a